### PR TITLE
Add SRT_wait_for_empty, change SRT_wait_for_idle's semantics.

### DIFF
--- a/doc/tutorial/05_main.c
+++ b/doc/tutorial/05_main.c
@@ -88,9 +88,8 @@ int main(void)
     pinball_target(NULL);
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
-    
+    SRT_wait_for_empty();
+
     SRT_stop();
     return 0;
 }

--- a/doc/tutorial/06_main.c
+++ b/doc/tutorial/06_main.c
@@ -88,8 +88,7 @@ int main(void)
     pinball_target(NULL);
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
+    SRT_wait_for_empty();
     
     SRT_stop();
     return 0;

--- a/doc/tutorial/07_main.c
+++ b/doc/tutorial/07_main.c
@@ -93,8 +93,7 @@ int main(void)
     pinball_target(NULL);
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
+    SRT_wait_for_empty();
     
     SRT_stop();
     return 0;

--- a/doc/tutorial/08_main.c
+++ b/doc/tutorial/08_main.c
@@ -101,8 +101,7 @@ int main(void)
     pinball_target(NULL);
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
+    SRT_wait_for_empty();
     
     SRT_stop();
     return 0;

--- a/doc/tutorial/09_main.c
+++ b/doc/tutorial/09_main.c
@@ -122,8 +122,7 @@ int main(void)
     pinball_target(NULL);
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
+    SRT_wait_for_empty();
     
     SRT_stop();
     return 0;

--- a/doc/tutorial/10_main.c
+++ b/doc/tutorial/10_main.c
@@ -139,9 +139,7 @@ int main(void)
     pinball_target(newTarget(1000));
     pinball_drain(NULL);
 
-    SRT_wait_for_idle();
-    sleep(3);
-    SRT_wait_for_idle();
+    SRT_wait_for_empty();
     
     SRT_stop();
     return 0;

--- a/doc/tutorial/pinball-tutorial.rst
+++ b/doc/tutorial/pinball-tutorial.rst
@@ -226,7 +226,7 @@ Error Handling
 --------------
 
 If we add a call to ``pinball_drain(NULL)`` before the last
-``SRT_wait_for_idle()`` call in **01_main.c** (on line 33), we get
+``SRT_wait_for_idle()`` call in **01_main.c** (on line 37), we get
 **02_main.c**.  Since the *drain* event is not handled when the
 *pinball* machine is in the *idle* state, this generates an error and
 returns early:
@@ -330,8 +330,8 @@ Running this new program gives us the expected
    like ``prepare-ball``. The ``Current_state_name`` for your state
    machine will always return the real name.
 
-Enter/Exit Functions
---------------------
+Enter/Exit Effects
+------------------
 
 So now we can have side effects, that's cool. They also give us a
 reason to be in different states, since we can react to the same event
@@ -433,6 +433,14 @@ used.
 This way, we can ignore all of the player's events for a little while
 to give them some time to think about whether or not cheating at
 pinball is a winning strategy for life.
+
+One more thing: Up to now, we've been calling ``SRT_wait_for_idle()``
+to drain the events out of the machine. Since that function is
+designed to be used in a mainloop, it doesn't wait for timers to
+expire before returning. That's useful in a lot of situations, but
+here we actually do want to just sit around doing nothing in ``main``
+until all the events have been handled. That's what
+``SRT_wait_for_empty()`` does in **05_main.c** on line 142.
 
 Default Handlers
 ================
@@ -573,7 +581,7 @@ program that uses everything we've seen so far:
    :include: 09_main.c
    :linenos:
 
-Note the ``SRT_wait_for_idle`` call on line 123. It's there because we
+Note the ``SRT_wait_for_idle`` call on line 125. It's there because we
 have state machines sending messages around to each other so we can't
 just queue up all our events and let loose.
 

--- a/include/smear.h
+++ b/include/smear.h
@@ -78,6 +78,10 @@ void SRT_stop(void);
 /* Block until there are no pending events, then return. */
 void SRT_wait_for_idle(void);
 
+/* Block until there are no events left in the queue, including
+ * delayed events, then return. */
+void SRT_wait_for_empty(void);
+
 /* Don't call this directly. */
 void SRT_send_message(const void *msg, void (handler)(const void *));
 

--- a/src/smear/smear.c
+++ b/src/smear/smear.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include "smeartime.h"
 #include "cancellable.h"
 #include "smear.h"
@@ -26,6 +27,7 @@ typedef struct
 
 static event_queue_t *q;
 static pthread_t tid;
+static sem_t idle_sem;
 
 /* The plan:
  *
@@ -41,11 +43,11 @@ static void flushEventQueue(void)
 {
     mq_msg_t *qmsg;
 
-    while(!eq_empty(q))
+    while (true)
     {
         qmsg = eq_next_event(q, get_now_ns());
         if (qmsg == NULL)
-            continue;
+            break;
         qmsg->handler(qmsg->wrapper);
         free(qmsg);
     }
@@ -55,7 +57,9 @@ static void *mainloop(void *unused)
 {
     while (true)
     {
+        sem_wait(&idle_sem);
         flushEventQueue();
+        sem_post(&idle_sem);
         sleep(0);
     }
     return NULL;
@@ -157,6 +161,7 @@ EXPORT_SYMBOL void SRT_cancel(cancel_token_t id)
 EXPORT_SYMBOL void SRT_init(void)
 {
     q = eq_new();
+    sem_init(&idle_sem, 0, 1);
 }
 
 EXPORT_SYMBOL void SRT_run(void)
@@ -170,6 +175,14 @@ EXPORT_SYMBOL void SRT_run(void)
 
 EXPORT_SYMBOL void SRT_wait_for_idle(void)
 {
+    sem_wait(&idle_sem);
+    flushEventQueue();
+    sem_post(&idle_sem);
+    return;
+}
+
+EXPORT_SYMBOL void SRT_wait_for_empty(void)
+{
     eq_wait_empty(q);
 }
 
@@ -179,4 +192,5 @@ EXPORT_SYMBOL void SRT_stop(void)
     pthread_cancel(tid);
     pthread_join(tid, &rv);
     eq_free(q);
+    sem_destroy(&idle_sem);
 }


### PR DESCRIPTION
After the cancellation changes, wait_for_idle effectively changed
meanings. Since timed events are now mixed in with all the rest of the
events in the queue, waiting for the queue to be empty meant stalling
until all the timers had fired.

In updating the tutorial examples, it became clear that this was not
good behavior for a function that might be called in a
mainloop. However, since it's still useful, I added SRT_wait_for_empty
to preserve the old (post-cancellation) semantics.

Also updated the tutorial to live in the new reality.