### PR TITLE
Add basic 128-bit unsigned multiple-precision arithmetic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJDIR := obj
 SRCDIR := src
-MODULES := smear cancelq
+MODULES := smear cancelq number
 LIBS :=
 SRC := 
 CC := /usr/bin/gcc

--- a/src/number/module.mk
+++ b/src/number/module.mk
@@ -1,0 +1,3 @@
+VPATH := $(VPATH) src/number/
+SRC += number.c
+INCLUDE += -Isrc/number/

--- a/src/number/number.c
+++ b/src/number/number.c
@@ -1,0 +1,213 @@
+#include <stdint.h>
+#include "number.h"
+
+int lt128(uint128_t n, uint128_t m)
+{
+    return n.hi < m.hi ||
+           (n.hi == m.hi && n.lo < m.lo);
+}
+
+int gt128(uint128_t n, uint128_t m)
+{
+    return n.hi > m.hi ||
+           (n.hi == m.hi && n.lo > m.lo);
+}
+
+int le128(uint128_t n, uint128_t m)
+{
+    return n.hi < m.hi ||
+           (n.hi == m.hi && n.lo <= m.lo);
+}
+
+int ge128(uint128_t n, uint128_t m)
+{
+    return n.hi > m.hi ||
+           (n.hi == m.hi && n.lo >= m.lo);
+}
+
+int eq128(uint128_t n, uint128_t m)
+{
+    return n.hi == m.hi && n.lo == m.lo;
+}
+
+int ne128(uint128_t n, uint128_t m)
+{
+    return n.hi != m.hi || n.lo != m.lo;
+}
+
+uint128_t add128(uint128_t n, uint128_t m)
+{
+    uint128_t sum = {0, 0};
+    sum.lo = n.lo + m.lo;
+    sum.hi = n.hi + m.hi +
+             (sum.lo < n.lo ? 1 : 0);
+    return sum;
+}
+
+uint128_t sub128(uint128_t n, uint128_t m)
+{
+    uint128_t diff = {0, 0};
+    diff.lo = n.lo - m.lo;
+    diff.hi = n.hi - m.hi -
+              (diff.lo > n.lo ? 1 : 0);
+    return diff;
+}
+
+uint128_t mul128(uint64_t n, uint64_t m)
+{
+    static const uint64_t mask = ((1ull << 32) - 1);
+    uint128_t prod = {0, 0};
+    uint64_t accum  = 0;
+    uint64_t n_hi   = 0, n_lo   = 0;
+    uint64_t m_hi   = 0, m_lo   = 0;
+    uint64_t mid = 0;
+    n_hi = n >> 32;
+    n_lo = n & mask;
+    m_hi = m >> 32;
+    m_lo = m & mask;
+
+    accum   = n_lo * m_lo;
+    prod.lo = accum & mask;
+    accum >>= 32;
+    accum += n_lo * m_hi;
+    mid = accum & mask;
+    prod.hi = accum >> 32;
+
+    accum  = n_hi * m_lo;
+    mid += accum & mask;
+    prod.lo += (mid & mask) << 32;
+    prod.hi += mid >> 32;
+    prod.hi += accum >> 32;
+    prod.hi += n_hi * m_hi;
+    return prod;
+}
+
+// This division algorithm was cribbed from Per Brinch
+// Hanson's paper "Multiple-Length Division Revisited."
+// It is like grade-school long division with a trick.
+//
+// To summarize, a prefix of each divisor and dividend
+// is used to perform "trial iteration" of division,
+// yielding an estimate of the quotient digit that is
+// at most one-greater than the actual quotient digit.
+// This is then corrected.
+//
+// The key is that three digits fit in a machine word.
+// Then the division of two digits into three takes a
+// single step.
+//
+// Here, a "digit" is 16 bits.  This was to make the
+// calculation obvious.  It is possible to handle the
+// 2-digit divisor case simply.  It is also possible to
+// shave off a division in the >2-digit divisor case,
+// but I don't want to bother with either of these
+// optimizations for now.  The implementation is less
+// obvious, and the base gets weird: floor(64/3) = 21.
+//
+// Of note is that normalization by a scaling factor is
+// skipped, resulting in more corrections.
+
+static const uint64_t qmask = ((1ull << 16) - 1);
+
+static inline uint16_t dig16(uint128_t n, size_t d)
+{
+    if (d < 4) {
+        return (n.lo >> (d * 16)) & qmask;
+    } else if (d < 8) {
+        return (n.hi >> ((d - 4) * 16)) & qmask;
+    }
+    return 0;
+}
+
+static inline void setdig16(uint128_t *n, size_t d, uint16_t m)
+{
+    if (d < 4) {
+        uint64_t mask = ~(qmask << (d * 16));
+        n->lo = (n->lo & mask) + (((uint64_t)m) << (d * 16));
+    } else if (d < 8) {
+        uint64_t mask = ~(qmask << ((d - 4) * 16));
+        n->hi = (n->hi & mask) + (((uint64_t)m) << ((d - 4) * 16));
+    }
+}
+
+static inline uint64_t min(uint64_t a, uint64_t b)
+{
+    return a < b ? a : b;
+}
+
+static uint128_t div128_16(uint128_t r, uint16_t d)
+{
+    // Algorithm 3
+    size_t n = 8;
+    // find number of significant digits in remainder
+    while (dig16(r, n - 1) == 0 && n > 1 && --n);
+    uint128_t q = {0, 0};
+    uint32_t c = 0;
+    for (size_t k = n; k-- > 0;) {
+        c = (c << 16) + dig16(r, k);
+        setdig16(&q, k, c / d);
+        c %= d;
+    }
+    return q;
+}
+
+uint128_t div128(uint128_t r, uint64_t d64)
+{
+    size_t n = 8;
+    size_t m = 4;
+
+    // up cast since it is simpler to divide like types.
+    uint128_t d = {0, 0};
+    d.lo = d64;
+
+    //r has n<=8 digits:
+    //r = r_{n - 1} * 16^{n - 1} + ... + r_0
+    while (dig16(r, n - 1) == 0 && n > 1 && --n);
+    //d has m<=4 digits:
+    //d = d_{m - 1} * 16^{m - 1} + ... + d_0
+    while (dig16(d, m - 1) == 0 && m > 1 && --m);
+
+    if (m > n) {
+        return (uint128_t){0, 0};
+    } else if (m == 1) {
+        return div128_16(r, d64 & qmask);
+    } else { // 2 <= m <= n
+        // Algorithms 5 and 8, excluding normalization
+        //q has n - m + 1 digits:
+        //q = q_{n - m} * 16^{n - m} + ... + q_0
+        uint128_t q = {0, 0};
+        uint64_t d_2 = 0;
+
+        d_2 = (((uint64_t)dig16(d, m - 1)) << 16)
+            +             dig16(d, m - 2);
+
+        for(int k = n - m; k >= 0; k--) {
+            uint16_t q_e = 0;
+            uint64_t r_3 = 0;
+
+            r_3 = (((uint64_t)dig16(r, k + m)) << 32)
+                + (((uint64_t)dig16(r, k + m - 1)) << 16)
+                +             dig16(r, k + m - 2);
+            q_e = min(r_3 / d_2, qmask);
+            // 0 <= q_k <= q_e <= q_k + 1 <= 2^16 (per eqn. 17)
+
+            // full lt is best-case constant-factor suboptimal
+            uint128_t prod = mul128(q_e, d64);
+            uint128_t r_m1 = {0, 0};
+            for(size_t j = 0; j < m + 1; ++j) {
+                setdig16(&r_m1, j, dig16(r, j + k));
+            }
+            if (lt128(r_m1, prod)) {
+                q_e = q_e - 1;
+                prod = sub128(prod, d);
+            }
+            setdig16(&q, k, q_e);
+            // shift left k digits
+            for(int j = m + k; j >= 0; --j) {
+                setdig16(&prod, j, dig16(prod, j - k));
+            }
+            r = sub128(r, prod);
+        }
+        return q;
+    }
+}

--- a/src/number/number.c
+++ b/src/number/number.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 #include "number.h"
 

--- a/src/number/number.h
+++ b/src/number/number.h
@@ -1,0 +1,23 @@
+#ifndef NUMBER_H
+#define NUMBER_H
+
+#include <stdint.h>
+
+typedef struct uint128_t {
+    uint64_t lo;
+    uint64_t hi;
+} uint128_t;
+
+int lt128(uint128_t, uint128_t);
+int gt128(uint128_t, uint128_t);
+int le128(uint128_t, uint128_t);
+int ge128(uint128_t, uint128_t);
+int eq128(uint128_t, uint128_t);
+int ne128(uint128_t, uint128_t);
+
+uint128_t add128(uint128_t, uint128_t);
+uint128_t sub128(uint128_t, uint128_t);
+uint128_t mul128(uint64_t, uint64_t);
+uint128_t div128(uint128_t, uint64_t);
+
+#endif

--- a/tests/test-number.c
+++ b/tests/test-number.c
@@ -1,0 +1,207 @@
+#include <assert.h>
+#include "number.h"
+
+int main(void)
+{
+    uint128_t zero = {0, 0};
+    uint128_t one  = {1, 0};
+    uint128_t two  = {2, 0};
+    uint128_t four = {4, 0};
+    uint128_t twotothe15 = {1ull<<15, 0};
+    uint128_t twotothe16 = {1ull<<16, 0};
+    uint128_t twotothe17 = {1ull<<17, 0};
+    uint128_t twotothe32minus1 = {(1ull<<32) - 1, 0};
+    uint128_t twotothe32 = {1ull<<32, 0};
+    uint128_t twotothe49 = {1ull<<49, 0};
+    uint128_t twotothe63 = {1ull<<63, 0};
+    uint128_t twotothe64minus2 = {-2, 0};
+    uint128_t twotothe64minus1 = {-1, 0};
+    uint128_t twotothe64 = {0, 1};
+    uint128_t twotothe64plus1 = {1, 1};
+    uint128_t twotothe65minus4 = {-4, 1};
+    uint128_t twotothe65minus2 = {-2, 1};
+    uint128_t twotothe65minus1 = {-1, 1};
+    uint128_t twotothe65 = {0, 2};
+    uint128_t twotothe65plus1 = {1, 2};
+    uint128_t twotothe65plus2 = {2, 2};
+    uint128_t twotothe66 = {0, 4};
+    uint128_t twotothe66plus1 = {1, 4};
+    uint128_t twotothe128minus2 = {-2, -1};
+    uint128_t twotothe128minus1 = {-1, -1};
+
+    // lt true
+    assert(lt128(one, two));
+    assert(lt128(twotothe64, twotothe65));
+    assert(lt128(twotothe66, twotothe66plus1));
+
+    // lt false
+    assert(!lt128(four, two));
+    assert(!lt128(two, two));
+    assert(!lt128(twotothe66, twotothe65));
+    assert(!lt128(twotothe65, twotothe65));
+    assert(!lt128(twotothe66plus1, twotothe66));
+    assert(!lt128(twotothe66plus1, twotothe66plus1));
+
+    // gt true
+    assert(gt128(four, two));
+    assert(gt128(twotothe66, twotothe65));
+    assert(gt128(twotothe66plus1, twotothe66));
+
+    // gt false
+    assert(!gt128(one, two));
+    assert(!gt128(two, two));
+    assert(!gt128(twotothe64, twotothe65));
+    assert(!gt128(twotothe65, twotothe65));
+    assert(!gt128(twotothe66, twotothe66plus1));
+    assert(!gt128(twotothe66plus1, twotothe66plus1));
+
+    // le true
+    assert(le128(one, two));
+    assert(le128(two, two));
+    assert(le128(twotothe64, twotothe65));
+    assert(le128(twotothe65, twotothe65));
+    assert(le128(twotothe66, twotothe66plus1));
+    assert(le128(twotothe66plus1, twotothe66plus1));
+
+    // le false
+    assert(!le128(four, two));
+    assert(!le128(twotothe66, twotothe65));
+    assert(!le128(twotothe66plus1, twotothe66));
+
+    // ge true
+    assert(ge128(four, two));
+    assert(ge128(two, two));
+    assert(ge128(twotothe66, twotothe65));
+    assert(ge128(twotothe65, twotothe65));
+    assert(ge128(twotothe66plus1, twotothe66));
+    assert(ge128(twotothe66plus1, twotothe66plus1));
+
+    // ge false
+    assert(!ge128(one, two));
+    assert(!ge128(twotothe64, twotothe65));
+    assert(!ge128(twotothe66, twotothe66plus1));
+
+    // eq true
+    assert(eq128(two, two));
+    assert(eq128(twotothe65, twotothe65));
+    assert(eq128(twotothe66plus1, twotothe66plus1));
+
+    // eq false
+    assert(!eq128(four, two));
+    assert(!eq128(twotothe66, twotothe65));
+    assert(!eq128(twotothe66plus1, twotothe66));
+
+    // ne true
+    assert(ne128(four, two));
+    assert(ne128(twotothe66, twotothe65));
+    assert(ne128(twotothe66plus1, twotothe66));
+
+    // ne false
+    assert(!ne128(two, two));
+    assert(!ne128(twotothe65, twotothe65));
+    assert(!ne128(twotothe66plus1, twotothe66plus1));
+
+    // add small
+    assert(eq128(two,               add128(zero, two)));
+    assert(eq128(two,               add128(two, zero)));
+    assert(eq128(four,              add128(two, two)));
+
+    // add mixed
+    assert(eq128(twotothe64,        add128(zero, twotothe64)));
+    assert(eq128(twotothe64,        add128(twotothe64, zero)));
+    assert(eq128(twotothe65minus2,  add128(twotothe64minus1, twotothe64minus1)));
+    assert(eq128(twotothe65,        add128(twotothe64minus1, twotothe64plus1)));
+    assert(eq128(twotothe65,        add128(twotothe64plus1, twotothe64minus1)));
+    assert(eq128(twotothe66plus1,   add128(one, twotothe66)));
+    assert(eq128(twotothe66plus1,   add128(twotothe66, one)));
+
+    // add large
+    assert(eq128(twotothe65,        add128(twotothe64, twotothe64)));
+    assert(eq128(twotothe65plus2,   add128(twotothe64plus1, twotothe64plus1)));
+    assert(eq128(twotothe66,        add128(twotothe65minus2, twotothe65plus2)));
+    assert(eq128(twotothe66,        add128(twotothe65plus2, twotothe65minus2)));
+
+    // add overflow
+    assert(eq128(zero,              add128(twotothe128minus1, one)));
+    assert(eq128(one,               add128(twotothe128minus1, two)));
+    assert(eq128(twotothe128minus2, add128(twotothe128minus1, twotothe128minus1)));
+
+    // sub small
+    assert(eq128(two,               sub128(two, zero)));
+    assert(eq128(zero,              sub128(two, two)));
+    assert(eq128(two,               sub128(four, two)));
+
+    // sub mixed
+    assert(eq128(twotothe64,        sub128(twotothe64, zero)));
+    assert(eq128(zero,              sub128(twotothe64, twotothe64)));
+    assert(eq128(twotothe64minus1,  sub128(twotothe65minus2, twotothe64minus1)));
+    assert(eq128(twotothe64plus1,   sub128(twotothe65, twotothe64minus1)));
+    assert(eq128(twotothe64minus1,  sub128(twotothe65, twotothe64plus1)));
+    assert(eq128(twotothe66,        sub128(twotothe66plus1, one)));
+    assert(eq128(one,               sub128(twotothe66plus1, twotothe66)));
+
+    // sub large
+    assert(eq128(twotothe64,        sub128(twotothe65, twotothe64)));
+    assert(eq128(twotothe64plus1,   sub128(twotothe65plus2, twotothe64plus1)));
+    assert(eq128(twotothe65minus2,  sub128(twotothe66, twotothe65plus2)));
+    assert(eq128(twotothe65plus2,   sub128(twotothe66, twotothe65minus2)));
+
+    // sub underflow
+    assert(eq128(one,               sub128(zero, twotothe128minus1)));
+    assert(eq128(two,               sub128(one, twotothe128minus1)));
+    assert(eq128(twotothe128minus1, sub128(twotothe128minus2, twotothe128minus1)));
+
+    // mul small
+    assert(eq128(zero,              mul128(0, 2)));
+    assert(eq128(zero,              mul128(2, 0)));
+    assert(eq128(two,               mul128(1, 2)));
+    assert(eq128(two,               mul128(2, 1)));
+    assert(eq128(four,              mul128(2, 2)));
+
+    // mul large
+    assert(eq128(twotothe64minus2,  mul128((1ull<<63)-1, 2)));
+    assert(eq128(twotothe64,        mul128(1ull<<63, 2)));
+    assert(eq128(twotothe64,        mul128(1ull<<32, 1ull<<32)));
+    assert(eq128(twotothe65minus4,  mul128((1ull<<63)-1, 4)));
+    assert(eq128(twotothe65,        mul128(2ull<<32, 1ull<<32)));
+
+    // div digits in numerator < digits in denominator
+    assert(eq128(zero,              div128(zero, 1ull<<16)));
+    assert(eq128(zero,              div128(one, 1ull<<16)));
+    assert(eq128(zero,              div128(two, 1ull<<16)));
+    assert(eq128(zero,              div128(twotothe16, 1ull<<32)));
+    assert(eq128(zero,              div128(twotothe32, 1ull<<48)));
+
+    // div numerator small, denominator < 2**16
+    assert(eq128(zero,              div128(zero, 1)));
+    assert(eq128(one,               div128(one, 1)));
+    assert(eq128(one,               div128(two, 2)));
+    assert(eq128(two,               div128(two, 1)));
+    assert(eq128(two,               div128(four, 2)));
+    assert(eq128(two,               div128(twotothe16, 1ull<<15)));
+    assert(eq128(twotothe15,        div128(twotothe16, 2)));
+    assert(eq128(twotothe17,        div128(twotothe32, 1ull<<15)));
+
+    // div numerator large, denominator < 2**16
+    assert(eq128(twotothe64,        div128(twotothe64, 1)));
+    assert(eq128(twotothe64plus1,   div128(twotothe64plus1, 1)));
+    assert(eq128(twotothe63,        div128(twotothe64, 2)));
+    assert(eq128(twotothe63,        div128(twotothe64plus1, 2)));
+    assert(eq128(twotothe49,        div128(twotothe64, 1ull<<15)));
+    assert(eq128(twotothe64plus1,   div128(twotothe65plus2, 2)));
+
+    // div numerator small
+    assert(eq128(one,               div128(twotothe16, 1ull<<16)));
+    assert(eq128(twotothe16,        div128(twotothe32, 1ull<<16)));
+    assert(eq128(twotothe17,        div128(twotothe49, 1ull<<32)));
+    assert(eq128(twotothe32minus1,  div128(twotothe64minus1, 1ull<<32)));
+
+    // div numerator large
+    assert(eq128(twotothe49,        div128(twotothe65, 1ull<<16)));
+    assert(eq128(twotothe49,        div128(twotothe65plus1, 1ull<<16)));
+    assert(eq128(twotothe65minus1,  div128(twotothe128minus1, 1ull<<63)));
+    assert(eq128(twotothe65minus1,  div128(twotothe128minus2, 1ull<<63)));
+
+    return 0;
+}
+

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -1,13 +1,16 @@
 VPATH += tests
 TESTS = test-cancelq-fill-then-cancel test-cancelq-fill-then-drain-all \
         test-cancelq-cancel-some-drain-some test-cancelq-not-cancellable \
-        test-cancelq-threads
+        test-cancelq-threads test-number
 
 
 test-cancelq-%: test-cancelq-%.c obj/cancellable.o
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ $^ $(LIBS)
 
 test-queue: test-queue.c obj/queue.o
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ $^
+
+test-number: test-number.c obj/number.o
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ $^
 
 .PHONY: runtests


### PR DESCRIPTION
Comparison, addition, subtraction, and multiplication are all simple,
expedient algorithms that are overly-specified to 128-bits.

However, the division algorithm (the difficult one) is general purpose.
It is from Per Brinch Hanson's paper "Multiple-Length Division Revisited,"
as explained in the comment in number.c above div128.  There are a few
shortcuts there that make assumptions about the size of the operands, but
those would be pretty to abstract if we want to extend to larger naturals.