### PR TITLE
Use QueryPerformanceCounter as the source of time on Windows.

### DIFF
--- a/src/smear/Windows_NT/smeartime.c
+++ b/src/smear/Windows_NT/smeartime.c
@@ -1,13 +1,30 @@
 #include <windows.h>
 #include <Winbase.h>
+#include <assert.h>
 #include "smeartime.h"
+#include "number.h"
 
-#define NANOSECONDS_PER_MILLISECOND 1000000
+#define NANOSECONDS_PER_SECOND 1000000000
 
 uint64_t get_now_ns(void)
 {
-    uint64_t now;
+    // Per MSDN, "[t]he frequency [...] is fixed at system boot and is
+    // consistent across all processors[, so it] need only be queried
+    // upon [...] initialization."  The units are counts/second, and it
+    // is guaranteed non-zero on WinXP or later.
+    static LARGE_INTEGER freq = { .QuadPart = 0 };
+    if (freq.QuadPart == 0) {
+        QueryPerformanceFrequency(&freq);
+    }
 
-    now = GetTickCount(); // Overflows pretty fast.
-    return now * NANOSECONDS_PER_MILLISECOND;
+    // Monotonic, <1us time stamp, units are counts
+    // Guaranteed to succeed on WinXP or later.
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    // For clock time, use GetSystemTimePreciseAsFileTime
+    uint128_t precise, ns;
+    precise = mul128(now.QuadPart, NANOSECONDS_PER_SECOND);
+    ns = div128(precise, freq.QuadPart);
+    assert(ns.hi == 0);
+    return ns.lo;
 }


### PR DESCRIPTION
Per the MSDN article "Acquiring high-resolution time stamp," QPC is the
proper source of accurate, precise, large, monotonic time that reflects
actual time passage (e.g., correctly accounting for standby/hibernate).
Moreover, it works as we need it to on all versions of Windows back to and
including WinXP, and works indentically for 32-bit and 64-bit Windows.

The disadvantages are that it cannot be meaningfully synchronized to an
external time reference, and that on some older processors it can be more
expensive to query than other methods, taking as long as 1us, which is
driven by hardware.